### PR TITLE
Deep Delete feature added

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To use with your Models add the `mixins` attribute to the definition object of y
 | option | type | description | required |
 | ------ | ---- | ----------- | -------- |
 |relations| [String] | relations which you want to delete together with current model | true |
-|deepDelete| [Boolean] | enable or disable the deep delete fonction. If activated, the CascadeDelete will be executed on the deleted related models as well (if they have the CascadeDelete mixin specified) | false |
+|deepDelete| [Boolean] | enable or disable the deep delete function. If activated, the CascadeDelete will be executed on the deleted related models as well (if they have the CascadeDelete mixin specified). If not used, disable it for performance matters | false |
 
 ## tests
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ To use with your Models add the `mixins` attribute to the definition object of y
      },
     "mixins": {
       "CascadeDelete": {
-         "relations": ["properties", "description"]
+         "relations": ["properties", "description"],
+         "deepDelete": true
        }
     }
   }
@@ -64,10 +65,11 @@ To use with your Models add the `mixins` attribute to the definition object of y
 | option | type | description | required |
 | ------ | ---- | ----------- | -------- |
 |relations| [String] | relations which you want to delete together with current model | true |
+|deepDelete| [Boolean] | enable or disable the deep delete fonction. If activated, the CascadeDelete will be executed on the deleted related models as well (if they have the CascadeDelete mixin specified) | false |
 
 ## tests
 
-Run the tests: 
+Run the tests:
 ```bash
   npm test
 ```
@@ -76,8 +78,3 @@ Run with debugging output on:
 ```bash
   DEBUG='loopback:mixins:cascade-delete' npm test
 ```
-
-
-
-
-

--- a/cascade-delete.js
+++ b/cascade-delete.js
@@ -59,10 +59,13 @@ module.exports = function (Model, options) {
                 where[relationKey] = modelId;
 
                 if (options.deepDelete) {
-                  return relationModel.find({where: where, fields: {id: true}}).then(function (instancesToDelete) {
+                  let relationModelIdName = relationModel.getIdName();
+                  let fields = {};
+                  fields[relationModelIdName] = true;
+                  return relationModel.find({where: where, fields: fields}).then(function (instancesToDelete) {
                     let deleteOperations = [];
                     for (let instance of instancesToDelete) {
-                      deleteOperations.push(relationModel.deleteById(instance.id));
+                      deleteOperations.push(relationModel.deleteById(instance[relationModelIdName]));
                     }
                     return Promise.all(deleteOperations);
                   });

--- a/cascade-delete.js
+++ b/cascade-delete.js
@@ -58,7 +58,17 @@ module.exports = function (Model, options) {
                 var where = {};
                 where[relationKey] = modelId;
 
-                return relationModel.destroyAll(where);
+                if (options.deepDelete && options.deepDelete == true) {
+                  return relationModel.find({where: where, fields: {id: true}}).then(function (instancesToDelete) {
+                    let deleteOperations = [];
+                    for (let instance of instancesToDelete) {
+                      deleteOperations.push(relationModel.deleteById(instance.id));
+                    }
+                    return Promise.all(deleteOperations);
+                  });
+                } else {
+                  return relationModel.destroyAll(where);
+                }
             }
         });
     }

--- a/cascade-delete.js
+++ b/cascade-delete.js
@@ -58,7 +58,7 @@ module.exports = function (Model, options) {
                 var where = {};
                 where[relationKey] = modelId;
 
-                if (options.deepDelete && options.deepDelete == true) {
+                if (options.deepDelete) {
                   return relationModel.find({where: where, fields: {id: true}}).then(function (instancesToDelete) {
                     let deleteOperations = [];
                     for (let instance of instancesToDelete) {
@@ -69,7 +69,7 @@ module.exports = function (Model, options) {
                 } else {
                   return relationModel.destroyAll(where);
                 }
-            }
+            };
         });
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-cascade-delete-mixin",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Loopback cascade delete mixin",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
I added deep deletion by replacing the destroyAll by a loop on detroyById because with destroyAll, loopback does not specify anything on the deleted items in the after delete operation hook, that's why deep delete wasn't working so far.
This way the after delete can be triggered correctly at every depth level for every related model deleted.

The option is configurable with 'deepDelete: true' in the mixin params, if there is no deepDelete specified or deepDelete is set to false. Then the script will operate without any of my modifications.

Even if this is quite lightweight, for performance matters, it's better to disable deepDelete if it's not used as it perform multiple delete action instead of one big delete action.

PS: I changed the version of the package from 1.0.1 to 1.1.0 because I though it can be considered as a new minor release of the package. I let you change it if you disagree