### PR TITLE
[#1] Added ability to use together with loopback-softdelete-mixin

### DIFF
--- a/cascade-delete.js
+++ b/cascade-delete.js
@@ -4,6 +4,19 @@ var debug = require('debug')('loopback:mixins:cascade-delete');
 var _ = require('lodash');
 
 module.exports = function (Model, options) {
+    function getWhereId (ctx){
+        var returnValue = undefined;
+
+        if (ctx.where) {
+            _.forEach(ctx.where.and, function (element) {
+                if (element.id !== undefined) {
+                    returnValue = element.id;
+                }
+            })
+        }
+
+        return returnValue
+    }
 
     Model.observe('after delete', function (ctx, next) {
         var name = idName(Model);
@@ -27,14 +40,51 @@ module.exports = function (Model, options) {
         });
 
         Promise.all(deletedRelations)
-            .then(function () {
-                debug('Cascade delete has successfully finished');
-                next();
-            })
-            .catch(function (err) {
-                debug('Error with cascading deletes', err);
-                next(err);
-            });
+          .then(function () {
+              debug('Cascade delete has successfully finished');
+              next();
+          })
+          .catch(function (err) {
+              debug('Error with cascading deletes', err);
+              next(err);
+          });
+    });
+
+    Model.observe('after save', function (ctx, next) {
+        var name = idName(Model);
+        var hasInstanceId = ctx.instance && ctx.instance[name];
+        var hasWhereId = getWhereId(ctx)
+        var hasMixinOption = options && _.isArray(options.relations);
+
+        if (!(hasWhereId || hasInstanceId)) {
+            debug('Skipping delete for ', Model.definition.name);
+            return next();
+        }
+
+        if (!hasMixinOption) {
+            debug('Skipping delete for', Model.definition.name, 'Please add mixin options');
+            return next();
+        }
+
+        if (ctx.data === undefined || ctx.data === null || ctx.data[options.marker] === false) {
+            debug('Skipping delete for ', Model.definition.name, 'Not marked as deleted via marker');
+            return next();
+        }
+        var modelInstanceId = getIdValue(Model, ctx.instance || ctx.where);
+
+        var deletedRelations = _.map(cascadeDeletes(), function (deleteRelation) {
+            return deleteRelation(modelInstanceId);
+        });
+
+        Promise.all(deletedRelations)
+          .then(function () {
+              debug('Cascade delete has successfully finished');
+              next();
+          })
+          .catch(function (err) {
+              debug('Error with cascading deletes', err);
+              next(err);
+          });
     });
 
     function cascadeDeletes() {


### PR DESCRIPTION
Added Checking after save to be able to use loopback-cascade-delete-mixin with loopback-softdelete-mixin
Introduced new option: marker 
```
"CascadeDelete": {
  "relations": [
    "relation1",
    "relation2"
  ],
  "marker": "_isDeleted"
}
```